### PR TITLE
add use token option

### DIFF
--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -7,7 +7,7 @@
         <option name="testRunner" value="GRADLE" />
         <option name="distributionType" value="DEFAULT_WRAPPED" />
         <option name="externalProjectPath" value="$PROJECT_DIR$" />
-        <option name="gradleJvm" value="jbr-17" />
+        <option name="gradleJvm" value="Embedded JDK" />
         <option name="modules">
           <set>
             <option value="$PROJECT_DIR$" />

--- a/app/src/main/java/jp/arkw/swarmskytox/MainActivity.java
+++ b/app/src/main/java/jp/arkw/swarmskytox/MainActivity.java
@@ -27,6 +27,7 @@ import java.util.ArrayList;
 public class MainActivity extends AppCompatActivity implements AdapterView.OnItemClickListener {
     private String host;
     private String userId;
+    private String token;
     private ListView listView;
     private ArrayList<String> arrayList = new ArrayList<>();
     private ArrayAdapter<String> arrayAdapter;
@@ -67,6 +68,7 @@ public class MainActivity extends AppCompatActivity implements AdapterView.OnIte
             Intent intent = new Intent(getApplication(), SettingsActivity.class);
             intent.putExtra("host", host);
             intent.putExtra("userId", userId);
+            intent.putExtra("token", token);
             startActivityForResult(intent, 1);
         }
         return true;
@@ -75,6 +77,7 @@ public class MainActivity extends AppCompatActivity implements AdapterView.OnIte
     private void update() {
         host = sharedPreferences.getString("host", "");
         userId = sharedPreferences.getString("userId", "");
+        token = sharedPreferences.getString("token", "");
         arrayList.clear();
         arrayAdapter.notifyDataSetChanged();
         if (!host.equals("") && !userId.equals("")) {
@@ -83,6 +86,10 @@ public class MainActivity extends AppCompatActivity implements AdapterView.OnIte
                 JSONObject request = new JSONObject();
                 request.put("userId", userId);
                 request.put("limit", 5);
+                if (token != "") {
+                    request.put("i", token);
+                }
+
                 new SendPostAsyncTask() {
                     @Override
                     protected void onPostExecute(String response) {
@@ -129,6 +136,7 @@ public class MainActivity extends AppCompatActivity implements AdapterView.OnIte
             Editor editor = sharedPreferences.edit();
             editor.putString("host", intent.getStringExtra("host"));
             editor.putString("userId", intent.getStringExtra("userId"));
+            editor.putString("token", intent.getStringExtra("token"));
             editor.apply();
             update();
         }

--- a/app/src/main/java/jp/arkw/swarmskytox/SettingsActivity.java
+++ b/app/src/main/java/jp/arkw/swarmskytox/SettingsActivity.java
@@ -12,6 +12,7 @@ import android.widget.TextView;
 public class SettingsActivity extends AppCompatActivity implements View.OnClickListener {
     private EditText editTextHost;
     private EditText editTextUserId;
+    private EditText editTextToken;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -22,8 +23,10 @@ public class SettingsActivity extends AppCompatActivity implements View.OnClickL
         Intent intent = getIntent();
         editTextHost = findViewById(R.id.edit_text_host);
         editTextUserId = findViewById(R.id.edit_text_userid);
+        editTextToken = findViewById(R.id.edit_text_token);
         editTextHost.setText(intent.getStringExtra("host"));
         editTextUserId.setText(intent.getStringExtra("userId"));
+        editTextToken.setText(intent.getStringExtra("token"));
         findViewById(R.id.button_ok).setOnClickListener(this);
         findViewById(R.id.text_view_url_web).setOnClickListener(this);
         findViewById(R.id.text_view_url_github).setOnClickListener(this);
@@ -35,6 +38,7 @@ public class SettingsActivity extends AppCompatActivity implements View.OnClickL
             Intent intent = new Intent(SettingsActivity.this, MainActivity.class);
             intent.putExtra("host", editTextHost.getText().toString());
             intent.putExtra("userId", editTextUserId.getText().toString());
+            intent.putExtra("token", editTextToken.getText().toString());
             setResult(RESULT_OK, intent);
             finish();
         } else if (v.getId() == R.id.text_view_url_web) {

--- a/app/src/main/res/layout/activity_settings.xml
+++ b/app/src/main/res/layout/activity_settings.xml
@@ -77,6 +77,29 @@
                 android:padding="4dp"
                 android:text="@string/settings_text_view_userid2" />
 
+            <TextView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="10dp"
+                android:paddingLeft="4dp"
+                android:text="@string/settings_edit_text_token"
+                android:textColor="?android:attr/textColorSecondary"
+                android:textSize="16sp" />
+
+            <EditText
+                android:id="@+id/edit_text_token"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:ems="10"
+                android:inputType="text"
+                android:textColor="?android:attr/textColorSecondary" />
+
+            <TextView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:padding="4dp"
+                android:text="@string/settings_text_view_token" />
+
             <Button
                 android:id="@+id/button_ok"
                 android:layout_width="100dp"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -9,9 +9,11 @@
     <string name="button_settings">設定</string>
     <string name="settings_edit_text_host">ホスト名</string>
     <string name="settings_edit_text_userid">ユーザID</string>
+    <string name="settings_edit_text_token">APIトークン(必要な場合のみ)</string>
     <string name="settings_text_view_host">例: misskey.io</string>
     <string name="settings_text_view_userid">例: 1a23bcdef4</string>
     <string name="settings_text_view_userid2">Misskeyの設定→その他→アカウント情報から確認できます</string>
+    <string name="settings_text_view_token">Misskeyの設定→API→アクセストークンの発行から取得できます</string>
     <string name="settings_button_ok">OK</string>
     <string name="settings_privacy">プライバシーポリシー</string>
 </resources>


### PR DESCRIPTION
## 変更内容
- アクセストークンが必須なサーバのアカウントでも動作できるように以下を追加
  - 設定画面でAPIトークンの入力欄の追加
  - APIトークン欄が空白ではない場合に、POSTするJSON内に`i`の値を追加してPOSTする処理の追加

## 背景
Firefish(Misskey12派生)では"非公開モード"の設定があり、これを有効にしている場合APIトークンがないと投稿の取得が行えないことから追加しました。

## 備考
- 特殊事例であることは認識しています。
- とりあえず目的の動作を達成すること、のみを念頭に作成したため、デザイン面の調整を一切行っていません…